### PR TITLE
Allow Graph GUID audience during JWT verification

### DIFF
--- a/server/services/jwt-validator.ts
+++ b/server/services/jwt-validator.ts
@@ -123,12 +123,17 @@ export class AzureAdJwtValidator {
 
       // Step 3: Verify token signature and standard claims
       // Note: jwt.verify doesn't support multiple issuers, so we'll validate issuer manually
+      // Allow Microsoft Graph tokens that use either the resource URL or the well-known GUID
+      const audienceOption = validationOptions.audience === "https://graph.microsoft.com"
+        ? ["https://graph.microsoft.com", "00000003-0000-0000-c000-000000000000"] as [string, ...string[]]
+        : validationOptions.audience;
+
       const payload = jwt.verify(token, signingKey, {
         algorithms: ['RS256'], // Azure AD uses RS256
         clockTolerance: this.config.clockTolerance,
-        audience: validationOptions.audience,
+        audience: audienceOption,
         // Skip issuer validation in jwt.verify since we handle it manually for multiple issuers
-      }) as AzureAdTokenPayload;
+      }) as unknown as AzureAdTokenPayload;
 
       // Step 4: Validate Azure AD specific claims
       await this.validateAzureAdClaims(payload, validationOptions);


### PR DESCRIPTION
## Summary
- allow Microsoft Graph access tokens that use the GUID audience to pass JWT verification
- reuse the manual issuer validation while broadening the accepted audience list used by jwt.verify

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd867dc4dc8321bd4068487fb6ef33