### PR TITLE
Handle embedded authentication contexts

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -54,9 +54,15 @@ export async function getAuthContext(): Promise<AuthContext> {
     // Verify authentication with backend
     const response = await fetch("/api/auth/me", {
       headers: {
-        Authorization: `Bearer ${accessToken.substring(0, 20)}...(truncated)`,
+        // Send the full access token to the API. Only log a redacted preview to avoid
+        // accidental truncation bugs while still keeping sensitive data out of logs.
+        Authorization: `Bearer ${accessToken}`,
       },
     });
+
+    console.log(
+      `[${timestamp}] 🔍 [AUTH CONTEXT] Sent Authorization header with bearer token (preview): ${accessToken.substring(0, 20)}...`
+    );
 
     console.log(`[${timestamp}] 🔍 [AUTH CONTEXT] Backend response status: ${response.status}`);
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- allow MSAL redirect authentication when the app is hosted inside embedded contexts
- add a redirect fallback in the login hook to handle blocked popup scenarios and iframe-hosted canvases
- process redirect results during MSAL initialization for consistent token hydration

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2555d8ecc8321ab4997945cf6ecde