### PR TITLE
Guard empty SharePoint site searches

### DIFF
--- a/client/src/hooks/use-sources.ts
+++ b/client/src/hooks/use-sources.ts
@@ -12,21 +12,27 @@ export function useSources({ accessToken }: UseSourcesProps) {
 
   // Search SharePoint sites
   const useSearchSites = (query: string = "") => {
+    const trimmedQuery = query.trim();
+
     return useQuery({
       queryKey: ["/api/sites", { query }],
       queryFn: async () => {
+        if (trimmedQuery.length === 0) {
+          return [];
+        }
+
         if (!accessToken) throw new Error("No access token");
-        
-        const response = await fetch(`/api/sites?query=${encodeURIComponent(query)}`, {
+
+        const response = await fetch(`/api/sites?query=${encodeURIComponent(trimmedQuery)}`, {
           headers: createAuthHeaders(accessToken),
         });
-        
+
         if (!response.ok) throw new Error("Failed to search sites");
-        
+
         const data = await response.json();
         return data.sites as SharePointSite[];
       },
-      enabled: !!accessToken,
+      enabled: !!accessToken && trimmedQuery.length > 0,
       staleTime: 5 * 60 * 1000, // 5 minutes
     });
   };

--- a/server/services/graph.ts
+++ b/server/services/graph.ts
@@ -123,16 +123,18 @@ export class GraphService {
 
 
   async searchSites(query: string = ""): Promise<SharePointSite[]> {
+    const trimmedQuery = query.trim();
+
+    if (!trimmedQuery) {
+      console.log("ℹ️ Skipping SharePoint site search due to empty query");
+      return [];
+    }
+
     return this.executeWithRetry(async () => {
-      console.log("🔍 Searching SharePoint sites with query:", query);
-      
-      let apiCall = this.client.api("/sites");
-      
-      if (query.trim()) {
-        // Use search with query
-        apiCall = apiCall.search(query);
-      }
-      
+      console.log("🔍 Searching SharePoint sites with query:", trimmedQuery);
+
+      const apiCall = this.client.api("/sites").search(trimmedQuery);
+
       const response = await apiCall
         .select("id,webUrl,displayName,description")
         .top(50)


### PR DESCRIPTION
## Summary
- prevent the client SharePoint site search query from running when the input is blank and return an empty result locally
- skip Microsoft Graph site search calls on the server when the trimmed query is empty to avoid unnecessary requests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d269dcfe408321a7910a0e3444da69